### PR TITLE
First implementation of immutable and reselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "extract-text-webpack-plugin": "^1.0.1",
+    "immutable": "^3.8.1",
     "manifest-revision-webpack-plugin": "^0.3.0",
     "react": "^15.3.2",
     "react-bootstrap": "^0.30.5",
@@ -21,6 +22,7 @@
     "react-router-redux": "^4.0.6",
     "react-typeahead": "^2.0.0-alpha.5",
     "redux": "^3.6.0",
+    "reselect": "^2.5.4",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/src/js_src/containers/search/filterSelector.js
+++ b/src/js_src/containers/search/filterSelector.js
@@ -5,6 +5,11 @@ import { connect } from 'react-redux';
 import style from './style.css';
 import { getQueryParamWithValueChanged } from '../../lib/searchHelpers';
 
+import {
+    selectActiveCategory,
+    selectAggregations,
+} from '../../selectors/searchSelectors';
+
 class FilterSelectorComponent extends Component {
   renderFilterValues(filterObj) {
     let values = filterObj.values;
@@ -77,8 +82,8 @@ FilterSelectorComponent.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    activeCategory:  state.search.activeCategory,
-    aggregations: state.search.aggregations,
+    activeCategory:  selectActiveCategory(state),
+    aggregations: selectAggregations(state),
     location: state.routing.locationBeforeTransitions
   };
 }

--- a/src/js_src/containers/search/index.js
+++ b/src/js_src/containers/search/index.js
@@ -135,13 +135,13 @@ function mapStateToProps(state) {
   let query = _location.query;
   let _isTable = (query.mode === 'table');
   return {
-    errorMessage: selectErrorMessage(),
-    isError: selectIsError(),
+    errorMessage: selectErrorMessage(state),
+    isError: selectIsError(state),
     isTable: _isTable,
     location: _location,
     query: query.q,
-    results: selectResults(),
-    total: selectTotal(),
+    results: selectResults(state),
+    total: selectTotal(state),
   };
 }
 

--- a/src/js_src/containers/search/index.js
+++ b/src/js_src/containers/search/index.js
@@ -12,6 +12,13 @@ import { SMALL_COL_CLASS, LARGE_COL_CLASS, SEARCH_API_ERROR_MESSAGE } from '../.
 import { getQueryParamWithValueChanged } from '../../lib/searchHelpers';
 import { receiveResponse, setError } from './searchActions';
 
+import {
+    selectErrorMessage,
+    selectIsError,
+    selectResults,
+    selectTotal,
+} from '../../selectors/searchSelectors';
+
 const BASE_SEARCH_URL = '/api/search';
 
 class SearchComponent extends Component {
@@ -128,13 +135,13 @@ function mapStateToProps(state) {
   let query = _location.query;
   let _isTable = (query.mode === 'table');
   return {
-    errorMessage: state.search.errorMessage,
-    isError: state.search.isError,
+    errorMessage: selectErrorMessage(),
+    isError: selectIsError(),
     isTable: _isTable,
     location: _location,
     query: query.q,
-    results: state.search.results,
-    total: state.search.total
+    results: selectResults(),
+    total: selectTotal(),
   };
 }
 

--- a/src/js_src/reducers/searchReducer.js
+++ b/src/js_src/reducers/searchReducer.js
@@ -22,7 +22,7 @@ const searchReducer = function (state = DEFAULT_STATE, action) {
     return state.set('errorMessage', action.payload).set('isError',true);
   case '@@router/LOCATION_CHANGE':
      // parse aggs to update active state during route change
-    return state.set('aggregations', parseAggs(state.aggregations, action.payload.query));
+    return state.set('aggregations', parseAggs(state.get('aggregations').toJS(), action.payload.query));
   case 'SEARCH_RESPONSE':
      // parse meta
     return state.set('isPending',false)

--- a/src/js_src/reducers/searchReducer.js
+++ b/src/js_src/reducers/searchReducer.js
@@ -17,39 +17,39 @@ const DEFAULT_STATE = fromJS({
 });
 
 const searchReducer = function (state = DEFAULT_STATE, action) {
-    switch(action.type) {
-        case 'SEARCH_ERROR':
-            return state.set('errorMessage', action.payload).set('isError',true);
-        case '@@router/LOCATION_CHANGE':
-            // parse aggs to update active state during route change
-            return state.set('aggregations', parseAggs(state.aggregations, action.payload.query));
-        case 'SEARCH_RESPONSE':
-            // parse meta
-            return state.set('isPending',false)
-                        .set('total', action.payload.total) 
-                        // parse aggregations
-                        .set('aggregations', parseAggs(action.payload.aggregations, action.queryObject)) 
-                        // parse results
-                        .set('results',action.payload.results.map( _d => { 
-                            let d = injectHighlightIntoResponse(_d);
-                            return {
-                                symbol: d.symbol,
-                                name: d.name,
-                                geneId: 'ID:12345678',
-                                sourceHref: 'https://www.google.com',
-                                synonyms: d.synonym,
-                                geneType: 'TYPE',
-                                genomicStartCoordinates: '',
-                                genomicStopCoordinates: '',
-                                relativeStartCoordinates: '',
-                                relativeStopCoordinates: '',
-                                species: d.organism,
-                                highlight: d.highlights
-                            };
-                        }));
-        default:
-            return state;
-    }
+  switch(action.type) {
+  case 'SEARCH_ERROR':
+    return state.set('errorMessage', action.payload).set('isError',true);
+  case '@@router/LOCATION_CHANGE':
+     // parse aggs to update active state during route change
+    return state.set('aggregations', parseAggs(state.aggregations, action.payload.query));
+  case 'SEARCH_RESPONSE':
+     // parse meta
+    return state.set('isPending',false)
+               .set('total', action.payload.total) 
+               // parse aggregations
+               .set('aggregations', parseAggs(action.payload.aggregations, action.queryObject)) 
+               // parse results
+               .set('results',action.payload.results.map( _d => { 
+                 let d = injectHighlightIntoResponse(_d);
+                 return {
+                   symbol: d.symbol,
+                   name: d.name,
+                   geneId: 'ID:12345678',
+                   sourceHref: 'https://www.google.com',
+                   synonyms: d.synonym,
+                   geneType: 'TYPE',
+                   genomicStartCoordinates: '',
+                   genomicStopCoordinates: '',
+                   relativeStartCoordinates: '',
+                   relativeStopCoordinates: '',
+                   species: d.organism,
+                   highlight: d.highlights
+                 };
+               }));
+  default:
+    return state;
+  }
 };
 
 function parseAggs(rawAggs, queryObject) {

--- a/src/js_src/selectors/searchSelectors.js
+++ b/src/js_src/selectors/searchSelectors.js
@@ -25,7 +25,7 @@ const selectIsError = () => createSelector(
 
 const selectResults = () => createSelector(
     selectSearchDomain(),
-    (search) => search.get('results').toArray()
+    (search) => search.get('results').toJS()
 );
 
 const selectTotal = () => createSelector(

--- a/src/js_src/selectors/searchSelectors.js
+++ b/src/js_src/selectors/searchSelectors.js
@@ -1,0 +1,43 @@
+import { createSelector } from 'reselect';
+
+// See https://github.com/reactjs/reselect
+// for details on using selectors.
+
+/**
+ * Direct selector to the search state.
+ */
+const selectSearchDomain = () => state => state.get('search');
+
+const selectSearch = () => createSelector(
+    selectSearchDomain(),
+    (searchDomain) => searchDomain.toJS()
+);
+
+const selectErrorMessage = () => createSelector(
+    selectSearch(),
+    (search) => search.errorMessage
+);
+
+const selectIsError = () => createSelector(
+    selectSearch(),
+    (search) => search.isError
+);
+
+const selectResults = () => createSelector(
+    selectSearch(),
+    (search) => search.results
+);
+
+const selectTotal = () => createSelector(
+    selectSearch(),
+    (search) => search.total
+);
+
+export {
+    selectSearchDomain,
+    selectSearch,
+    selectErrorMessage,
+    selectIsError,
+    selectResults,
+    selectTotal,
+};

--- a/src/js_src/selectors/searchSelectors.js
+++ b/src/js_src/selectors/searchSelectors.js
@@ -6,39 +6,39 @@ import { createSelector } from 'reselect';
 /**
  * Direct selector to the search state.
  */
-const selectSearchDomain = () => state => state.get('search');
+const selectSearchDomain = (state) => state.search;
 
-const selectSearch = () => createSelector(
-    selectSearchDomain(),
+const selectSearch = createSelector(
+    [selectSearchDomain],
     (searchDomain) => searchDomain.toJS()
 );
 
-const selectErrorMessage = () => createSelector(
-    selectSearchDomain(),
+const selectErrorMessage = createSelector(
+    [selectSearchDomain],
     (search) => search.get('errorMessage')
 );
 
-const selectIsError = () => createSelector(
-    selectSearchDomain(),
+const selectIsError = createSelector(
+    [selectSearchDomain],
     (search) => search.get('isError')
 );
 
-const selectResults = () => createSelector(
-    selectSearchDomain(),
+const selectResults = createSelector(
+    [selectSearchDomain],
     (search) => search.get('results').toJS()
 );
 
-const selectTotal = () => createSelector(
-    selectSearchDomain(),
+const selectTotal = createSelector(
+    [selectSearchDomain],
     (search) => search.get('total')
 );
 
-const selectActiveCategory = () => createSelector(
-    selectSearchDomain(),
+const selectActiveCategory = createSelector(
+    [selectSearchDomain],
     (search) => search.get('activeCategory')
 );
-const selectAggregations = () => createSelector(
-    selectSearchDomain(),
+const selectAggregations = createSelector(
+    [selectSearchDomain],
     (search) => search.get('aggregations').toJS()
 );
 

--- a/src/js_src/selectors/searchSelectors.js
+++ b/src/js_src/selectors/searchSelectors.js
@@ -14,23 +14,32 @@ const selectSearch = () => createSelector(
 );
 
 const selectErrorMessage = () => createSelector(
-    selectSearch(),
-    (search) => search.errorMessage
+    selectSearchDomain(),
+    (search) => search.get('errorMessage')
 );
 
 const selectIsError = () => createSelector(
-    selectSearch(),
-    (search) => search.isError
+    selectSearchDomain(),
+    (search) => search.get('isError')
 );
 
 const selectResults = () => createSelector(
-    selectSearch(),
-    (search) => search.results
+    selectSearchDomain(),
+    (search) => search.get('results').toArray()
 );
 
 const selectTotal = () => createSelector(
-    selectSearch(),
-    (search) => search.total
+    selectSearchDomain(),
+    (search) => search.get('total')
+);
+
+const selectActiveCategory = () => createSelector(
+    selectSearchDomain(),
+    (search) => search.get('activeCategory')
+);
+const selectAggregations = () => createSelector(
+    selectSearchDomain(),
+    (search) => search.get('aggregations').toJS()
 );
 
 export {
@@ -40,4 +49,6 @@ export {
     selectIsError,
     selectResults,
     selectTotal,
+    selectActiveCategory,
+    selectAggregations,
 };

--- a/src/js_src/selectors/tests/searchSelectors.test.js
+++ b/src/js_src/selectors/tests/searchSelectors.test.js
@@ -12,84 +12,75 @@ import {
     selectAggregations,
 } from '../searchSelectors';
 
-/*const stateJS = {
-    search: {
-        errorMessage: 'This is an error',
-    }
-};
-const state = fromJS(stateJS);*/
-
 describe('SearchSelectors', () => {
-    const searchDomainSelector = selectSearchDomain();
     it('selectSearchDomain', () => {
-        const searchState = fromJS({});
-        const mockedState = fromJS({
-            search: searchState,
+        const searchState = fromJS({
+            isError: true,
+            results: [],
         });
-        assert.equal(searchDomainSelector(mockedState),searchState);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.equal(selectSearchDomain(mockedState),searchState);
     });
 
-    const searchSelector = selectSearch();
     it('selectSearch', () => {
-        const searchState = {};
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.deepEqual(searchSelector(mockedState),searchState);
+        const searchState = {
+            isError: true,
+            results: [],
+        };
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.deepEqual(selectSearch(mockedState),searchState);
     });
 
-    const resultsSelector = selectResults();
     it('selectResults', () => {
         const searchState = { results: [1,2,3,4] };
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.deepEqual(resultsSelector(mockedState),searchState.results);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.deepEqual(selectResults(mockedState),searchState.results);
     });
 
-    const errorMessageSelector = selectErrorMessage();
     it('selectErrorMessage', () => {
         const searchState = { errorMessage: 'This is an error' };
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.deepEqual(errorMessageSelector(mockedState),searchState.errorMessage);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.deepEqual(selectErrorMessage(mockedState),searchState.errorMessage);
     });
-
-    const isErrorSelector = selectIsError();
+    
     it('selectIsError', () => {
         const searchState = { isError: true };
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.equal(isErrorSelector(mockedState),searchState.isError);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.equal(selectIsError(mockedState),searchState.isError);
     });
 
-    const totalSelector = selectTotal();
     it('selectTotal', () => {
         const searchState = { total: 10 };
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.equal(totalSelector(mockedState),searchState.total);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.equal(selectTotal(mockedState),searchState.total);
     });
 
-    const activeCategorySelector = selectActiveCategory();
     it('selectActiveCategory', () => {
         const searchState = { activeCategory: 'my category' };
-        const mockedState = fromJS({
-            search: searchState,
-        });
-        assert.equal(activeCategorySelector(mockedState),searchState.activeCategory);
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.equal(selectActiveCategory(mockedState),searchState.activeCategory);
     });
 
-    const aggregationsSelector = selectAggregations();
     it('selectAggregations', () => {
         const searchState = { aggregations: [{name:'myagg1', displayName:'My agg1'},{name:'myagg2', displayName:'My agg2'}]};
-        const mockedState = fromJS({
-            search: searchState,
+        const mockedState = {
+            search: fromJS(searchState),
+        };
+        assert.deepEqual(selectAggregations(mockedState),searchState.aggregations);
         });
-        assert.deepEqual(aggregationsSelector(mockedState),searchState.aggregations);
-    });
 });
 

--- a/src/js_src/selectors/tests/searchSelectors.test.js
+++ b/src/js_src/selectors/tests/searchSelectors.test.js
@@ -1,0 +1,95 @@
+import assert from 'assert';
+import { fromJS } from 'immutable';
+
+import {
+    selectSearchDomain,
+    selectSearch,
+    selectErrorMessage,
+    selectIsError,
+    selectResults,
+    selectTotal,
+    selectActiveCategory,
+    selectAggregations,
+} from '../searchSelectors';
+
+/*const stateJS = {
+    search: {
+        errorMessage: 'This is an error',
+    }
+};
+const state = fromJS(stateJS);*/
+
+describe('SearchSelectors', () => {
+    const searchDomainSelector = selectSearchDomain();
+    it('selectSearchDomain', () => {
+        const searchState = fromJS({});
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.equal(searchDomainSelector(mockedState),searchState);
+    });
+
+    const searchSelector = selectSearch();
+    it('selectSearch', () => {
+        const searchState = {};
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.deepEqual(searchSelector(mockedState),searchState);
+    });
+
+    const resultsSelector = selectResults();
+    it('selectResults', () => {
+        const searchState = { results: [1,2,3,4] };
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.deepEqual(resultsSelector(mockedState),searchState.results);
+    });
+
+    const errorMessageSelector = selectErrorMessage();
+    it('selectErrorMessage', () => {
+        const searchState = { errorMessage: 'This is an error' };
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.deepEqual(errorMessageSelector(mockedState),searchState.errorMessage);
+    });
+
+    const isErrorSelector = selectIsError();
+    it('selectIsError', () => {
+        const searchState = { isError: true };
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.equal(isErrorSelector(mockedState),searchState.isError);
+    });
+
+    const totalSelector = selectTotal();
+    it('selectTotal', () => {
+        const searchState = { total: 10 };
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.equal(totalSelector(mockedState),searchState.total);
+    });
+
+    const activeCategorySelector = selectActiveCategory();
+    it('selectActiveCategory', () => {
+        const searchState = { activeCategory: 'my category' };
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.equal(activeCategorySelector(mockedState),searchState.activeCategory);
+    });
+
+    const aggregationsSelector = selectAggregations();
+    it('selectAggregations', () => {
+        const searchState = { aggregations: [{name:'myagg1', displayName:'My agg1'},{name:'myagg2', displayName:'My agg2'}]};
+        const mockedState = fromJS({
+            search: searchState,
+        });
+        assert.deepEqual(aggregationsSelector(mockedState),searchState.aggregations);
+    });
+});
+


### PR DESCRIPTION
First pass at adding immutable to address #5.  All tests are passing now.

The reducer initializes the immutable store (see fromJS on the DEFAULT_STATE) and uses immutable operations to return new modified copies of state.  I did not attempt to deal with the nested object state fields (results, aggregations) and left them as simple key/value fields.  This should probably be changed once the structure of the nested objects settles down.  The reselect library is used to create performant selectors that populate the container props from the state.
