### PR TITLE
Addition of JSON schemas & basic validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ virtualenv -p python2 ~/.virtualenvs/agr_prototype
 ```bash
 source ~/.virtualenvs/agr_prototype/bin/activate
 make build
+make index
 make run
 ```
 

--- a/schema/FB_gene_example.json
+++ b/schema/FB_gene_example.json
@@ -1,0 +1,19 @@
+{  
+  "primaryId": "FBgn0000490",
+  "name": "decapentaplegic",
+  "taxonId": "7227",
+  "symbol": "dpp",
+  "geneSynopsis": "Decapentaplegic is a ligand of the transforming growth factor-β signaling pathway that signals through Smad transcription factors. Dpp acts as a morphogen that contributes to growth regulation, patterning and stem cell fate.",
+  "soTermId": "SO:0001217",
+  "synonyms": ["Tegula", "DPP-C", "blink", "blk", "heldout"],
+  "crossReferences": [
+    { "dataSource": "NCBI", "id": "33432" },
+    { "dataSource": "UniProtKB", "id": "P07713"}
+  ],
+  "secondaryIds": ["CG9885"],
+  "metaData": {
+    "dateProduced": "2017-01-26T15:00:42-05:00",
+    "dataProvider": "FB",
+    "release": "FB2016_05"
+  }
+}

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,17 @@
+AGR JSON Schemas
+================
+
+This directory contains JSON schemas used to define data for integration into AGR.
+
+|Schema|Description|
+|---------|----------|
+|basicGeneInformation|An entry with Gene information from a MOD.  Gene set includes: genes, psuedogenes and not-protein coding genes.  It does not include engineered foreign genes, transcripts or other features.|
+|dataProvider|An standard set of information regarding data source and taxon ids for the AGR.|
+|crossReference|An crossReference entity (_e.g._: NCBIGENE links, UniProt Links, and links back to MODs).
+|metaData|An standard set of information regarding when and from whom the load was generated.|
+
+Validation
+----------
+The python script "agr_validate.py" can be used to validate a JSON entry against a schema for testing/development purposes.
+Usage is as follows: 
+`validate.py -d test_data.json -s basicGeneInformation.json`

--- a/schema/agr_validate.py
+++ b/schema/agr_validate.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import json
+import strict_rfc3339
+import os
+import argparse
+import sys
+import jsonschema as js
+
+parser = argparse.ArgumentParser(description='This is a simple validator for JSON schema.')
+
+parser.add_argument('-d','--data', help='JSON data file',required=True)
+parser.add_argument('-s','--schema',help='JSON schema file', required=True)
+args = parser.parse_args() 
+
+data_file_name = args.data
+with open(data_file_name) as data_file:
+	data = json.load(data_file)
+data_file.closed
+
+schema_file_name = args.schema
+with open(schema_file_name) as schema_file:
+ 	schema = json.load(schema_file)
+schema_file.closed
+
+# Defining a resolver for relative paths and schema issues, see https://github.com/Julian/jsonschema/issues/313
+# and https://github.com/Julian/jsonschema/issues/274
+sSchemaDir = os.path.dirname(os.path.abspath(schema_file_name))
+oResolver = js.RefResolver(base_uri = 'file://' + sSchemaDir + '/', referrer = schema)
+
+try:
+	js.validate(data, schema, format_checker=js.FormatChecker(), resolver=oResolver)
+	print "'%s' successfully validated against '%s'" % (data_file_name, schema_file_name)
+except js.ValidationError as e:
+	print e.message
+except js.SchemaError as e:
+	print e.messagep

--- a/schema/basicGeneInformation.json
+++ b/schema/basicGeneInformation.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Basic Gene Information",
+	"description": "An entry with Gene information from a MOD.  Gene set includes: genes, psuedogenes and not-protein coding genes.  It does not include engineered foreign genes, transcripts or other features.",
+	"id": "basicGeneInformation.json#",
+	"type": "object",
+  "required": [ "primaryId", "metaData", "name", "taxonId", "symbol", "soTermId" ],
+	"properties": {
+		"primaryId": {                                
+			"type": "string",
+			"description": "The primary (MOD) ID for an entity."
+		},
+    "name": { 
+      "type": "string",
+      "description": "The name of the entity."
+    },
+    "taxonId": {
+	    "$ref" : "dataProvider.json#/properties/taxonId",
+	    "description" : "The taxonId for the species of the gene entity."
+    },
+    "symbol": {
+		  "type": "string",
+		  "description": "The symbol for the gene entity."
+		},
+		"geneSynopsis": {
+			"type": "string",
+			"description": "Human readable gene description or synopsis"
+		},
+    "soTermId": { 
+      "type": "string",
+      "description": "The SO Term that represents as best we can, the bioType, or featureType of the object in the file.  DQMs agree that this should be a standardized set."
+    },
+    "synonyms": {
+			"type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+	  },
+	  "crossReferences": {
+	    "description":"Collection holding a limited set (for now) of database cross references for each gene.  That set is defined in geneCrossReferences.json dataSoruce enumeration.  NCBI GENE means just the NCBI Gene reference.  UniProtKB is swissprot and trembl.  Ensembl is just the GENE id for now (not transcript nor protein).  Vega was eliminated as it did not apply to all organisms in the repository.",
+	    "type": "array",
+	    "items": {
+	      "$ref" : "crossReferences.json#"
+	    },
+	    "uniqueItems": true
+	  },
+	  "secondaryIds": {
+	    "description": "Collection of MOD-specific IDs that have been merged into gene entity.",
+	    "type": "array",
+	    "items": {
+	      "type": "string"
+	    },
+	    "uniqueItems": true
+	  },
+	  "metaData": {
+		  "$ref": "metaData.json#",
+		  "description": "meta data of the load file as defined in metaData.json.  we are currently looking for a way to record this in the header of the JSON spec file, just once, instead of repeating it over and over in the file."
+		  }
+	}
+}

--- a/schema/crossReferences.json
+++ b/schema/crossReferences.json
@@ -1,0 +1,18 @@
+{
+  "title": "Cross Reference Information For Gene Entities",
+  "description": "An crossReference entity (ie: NCBIGENE links, UniProt Links and links back to MODs",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [ "dataSource","id"],
+  "id": "geneCrossReference.json#",
+  "properties": {
+    "dataProvider": {
+      "$ref" : "dataProvider.json#",
+      "description":"Constraints the dataProvider to conform to the dataProvider schema.  This schema enforces that a dataProvider provide the taxonId of the record being added, as well as the database source.  see dataProvider.json for more information."
+    },
+    "id": {
+      "type": "string",
+      "description": "The primary identifier of the related resource."        
+    }
+  }
+}

--- a/schema/dataProvider.json
+++ b/schema/dataProvider.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "MOD Species and Taxon Information",
+	"id": "dataProvider.json#",
+	"description": "An standard set of information regarding data source and taxon ids for the AGR",
+	"type": "object",
+  "properties": {
+    "dataProvider": {
+      "description": "The MOD, human, or other source of data. AGR currently supports the entities listed below.",
+      "enum": [ "FB", "MGI", "RGD", "SGD", "ZFIN", "WB", "DRSC","NCBI GENE","UniProtKB","ENSEMBL","RNAcentral"]
+    },
+    "taxonId": {
+      "description": "The taxon id of the species of the entity. AGR currently supports the ids listed below.",
+      "enum" : ["7955","6239","10090","10116","4932","7227"]
+    }
+  }
+}

--- a/schema/metaData.json
+++ b/schema/metaData.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Load File Meta Data",
+	"id": "metaData.json",
+	"description": "An standard set of information regarding when and from whom the load was genearted",
+	"type": "object",
+  "properties": {
+		  "description": "The metadata of the load file.",
+		    "properties": {
+		      "dateProduced" : {
+	          "type": "string",
+	          "format": "date-time",
+	          "description": "Date this entity was dumped from it's primary data source."
+	        },
+	        "dataProvider" : {
+	          "$ref" : "dataProvider.json#/dataProvider",
+	          "description" : "MOD or source of data."
+	        },
+	        "release" : {
+	          "type": "string",
+	          "description" : "The release or version of the data, if available."
+	        },
+	        "required": [ "dateProduced", "dataProvider"]
+		    }
+		}
+}


### PR DESCRIPTION
I've created a folder containing the JSON schemas created by the Data Quartermasters group. Also within the folder is a simple FlyBase example and a basic Python script for testing JSON data against the schemas.

There's been much talk of Swagger, which sounds like an awesome approach, but we didn't have anyone around who was familiar with it at the time (lots of busy folks). So, we went "old school" and generated these schemas manually. We're absolutely open for more discussion and assistance on our approach.

This pull request closes #67 .