### PR TITLE
Elasticsearch 5 mapping & query fixes

### DIFF
--- a/scripts/elastic_search/mapping.py
+++ b/scripts/elastic_search/mapping.py
@@ -60,7 +60,7 @@ mapping = {
                     "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "text"
+                            "type": "keyword"
                         }
                     }
                 },

--- a/scripts/elastic_search/mapping.py
+++ b/scripts/elastic_search/mapping.py
@@ -40,193 +40,187 @@ mapping = {
         "searchable_item": {
             "properties": {
                 "name": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "symbol": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         }
                     }
                 },
                 "gene_symbol": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols"
                 },
                 "gene_synonyms": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols"
                 },
                 "gene_type": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "text"
                         }
                     }
                 },
                 "gene_chromosomes": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "gene_chromosome_starts": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "gene_chromosome_ends": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "gene_chromosome_strand": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "description": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "external_ids": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols"
                 },
                 "gene_biological_process": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         },
                         "symbol": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         }
 
                     }
                 },
                 "gene_molecular_function": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         },
                         "symbol": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         }
 
                     }
                 },
                 "gene_cellular_component": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         },
                         "symbol": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         }
 
                     }
                 },
                 "species": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "href": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols"
                 },
                 "category": {
-                    "type": "string",
-                    "analyzer": "symbols"
-                },
-                "go_type": {
-                    "type": "string",
+                    "type": "keyword",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
+                        },
+                        "symbol": {
+                            "type": "text",
+                            "analyzer": "symbols"
+                        }
+                    }
+                },
+                "go_type": {
+                    "type": "text",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
                         }
                     }
                 },
                 "go_genes": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "go_species": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "disease_genes": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "disease_species": {
-                    "type": "string",
+                    "type": "text",
                     "fields": {
                         "raw": {
-                            "type": "string",
-                            "index": "not_analyzed"
+                            "type": "keyword"
                         }
                     }
                 },
                 "disease_synonyms": {
-                    "type": "string"
+                    "type": "text"
                 },
                 "id": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols"
                 },
                 "name_key": {
-                    "type": "string",
+                    "type": "text",
                     "analyzer": "symbols",
                     "fields": {
                         "autocomplete": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "autocomplete"
                         }
                     }
@@ -234,24 +228,24 @@ mapping = {
                 "homologs": {
                     "properties": {
                         "symbol": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         },
                         "species": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "relationship_type": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "ancestral": {
-                            "type": "string"
+                            "type": "text"
                         },
                         "panther_family": {
-                            "type": "string",
+                            "type": "text",
                             "analyzer": "symbols"
                         },
                         "href": {
-                            "type": "string"
+                            "type": "text"
                         }
                     }
                 }

--- a/src/search.py
+++ b/src/search.py
@@ -1,3 +1,5 @@
+import json
+
 def build_es_aggregation_body_request(es_query, category, category_filters):
     agg_query_body = {
         'query': es_query,
@@ -102,20 +104,18 @@ def build_search_query(query, search_fields, category, category_filters, args):
         return es_query
 
     query = {
-        'filtered': {
-            'query': es_query,
-            'filter': {
-                'bool': {
-                    'must': [{'term': {'category': category}}]
-                }
-            }
+        'bool': {
+            'must': [
+                {'term': {'category': category}},
+                es_query
+            ]
         }
     }
 
     if category in category_filters.keys():
         for item in category_filters[category]:
             for param in args.getlist(item, None):
-                query['filtered']['filter']['bool']['must'].append({
+                query['bool']['must'].append({
                     'term': {
                         (item + ".raw"): param
                     }

--- a/test/unit_tests/test_search.py
+++ b/test/unit_tests/test_search.py
@@ -110,14 +110,13 @@ class SearchHelpersTest(unittest.TestCase):
         es_query = build_search_params(query, fields)
 
         self.assertEqual(build_search_query(query, fields, category, category_filters, args), {
-            'filtered': {
-                'query': es_query,
-                'filter': {
-                    'bool': {
-                        'must': [{'term': {'category': category}}]
-                    }
-                }
+            'bool': {
+                    'must': [
+                        {'term': {'category': category}},
+                        es_query
+                    ]
             }
+
         })
 
     def test_build_search_query_should_filter_subcategories_if_passed(self):
@@ -137,18 +136,14 @@ class SearchHelpersTest(unittest.TestCase):
         es_query = build_search_params(query, fields)
 
         self.assertEqual(build_search_query(query, fields, category, category_filters, args), {
-            'filtered': {
-                'query': es_query,
-                'filter': {
-                    'bool': {
-                        'must': [
-                            {'term': {'category': category}},
-                            {'term': {'go_names.raw': 'A'}},
-                            {'term': {'go_names.raw': 'B'}},
-                            {'term': {'go_names.raw': 'C'}}
-                        ]
-                    }
-                }
+            'bool': {
+                'must': [
+                    {'term': {'category': category}},
+                    es_query,
+                    {'term': {'go_names.raw': 'A'}},
+                    {'term': {'go_names.raw': 'B'}},
+                    {'term': {'go_names.raw': 'C'}}
+                ]
             }
         })
 


### PR DESCRIPTION
This change Fixes #75 

The mapping is updated to use keyword rather than string, and the queries are updated so that they won't use the 'filtered' query clause.  

I did some quick testing to confirm that filters were being applied and that the number of results actually went down as I clicked facets.  I also did a few basic searches, and the results looked reasonable...but more testing wouldn't hurt!

@pedrohr Maybe just a 5 minute check through this, if you have time...?
